### PR TITLE
Sequenced packet and systemd socket activation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ cabal.project.local~
 stack.yaml
 cabal.config
 *.swp
+examples/bytemunch/bytemunch
+examples/slowpoke

--- a/examples/bytemunch/README.md
+++ b/examples/bytemunch/README.md
@@ -1,0 +1,16 @@
+# bytemunch
+
+This is an example application that demonstrates how `sockets` can be
+used with systemd activation sockets. There is a `service` file and
+a `socket` file in this directory for use with systemd. To try this
+out, copy both files to `~/.config/systemd/system/`. From the top-level
+directory of the sockets library run:
+
+    cabal build --write-ghc-environment-files=always
+    ghc -threaded examples/bytemunch/bytemunch.hs
+    cp examples/bytemunch/bytemunch ~/.local/bin/
+
+Activate the service and then start feeding in bytes:
+
+    systemctl --user start bytemunch
+    echo "Hello World" > /dev/tcp/localhost/9999

--- a/examples/bytemunch/bytemunch.hs
+++ b/examples/bytemunch/bytemunch.hs
@@ -1,0 +1,113 @@
+{-# language BangPatterns #-}
+{-# language DeriveAnyClass #-}
+{-# language DerivingStrategies #-}
+{-# language BangPatterns #-}
+{-# language LambdaCase #-}
+{-# language GADTs #-}
+{-# language NamedFieldPuns #-}
+{-# language OverloadedStrings #-}
+{-# language ScopedTypeVariables #-}
+{-# language TypeApplications #-}
+
+{-# OPTIONS_GHC -fforce-recomp -O2 -Wall -Werror #-}
+
+import Control.Exception (Exception,throwIO)
+import Control.Concurrent (forkIO)
+import Control.Concurrent.STM (TVar)
+import Control.Concurrent.MVar (MVar,newEmptyMVar,putMVar,takeMVar)
+import qualified Control.Concurrent.STM as STM
+import qualified Control.Exception as E
+import qualified Data.ByteString.Char8 as BC8
+import qualified Data.Primitive as PM
+import qualified Net.IPv4 as IPv4
+import qualified Socket.Stream.IPv4 as Stream
+import qualified Socket.Stream.Uninterruptible.Bytes as Stream
+import qualified System.IO as IO
+
+main :: IO ()
+main = do
+  Stream.systemdListener >>= \case
+    Right listener -> do
+      BC8.hPutStr IO.stderr "[MAIN__] Acquired listener from systemd.\n"
+      run listener
+    Left _ -> do
+      BC8.hPutStr IO.stderr "[MAIN__] Not running as a socket-activated service.\n"
+      BC8.hPutStr IO.stderr "[MAIN__] Listening on port 9998.\n"
+      Stream.listen (Stream.Peer IPv4.loopback 9998) >>= \case
+        Left err -> throwIO err
+        Right (listener, _) -> run listener
+
+run :: Stream.Listener -> IO ()
+run !listener = do
+  terminating <- STM.newTVarIO False
+  counter <- STM.newTVarIO (0 :: Int)
+  done <- newEmptyMVar @()
+  _ <- forkIO (listenForever done counter terminating listener)
+  E.catch (takeMVar done)
+    (\(e :: E.AsyncException) -> do
+      IO.hFlush IO.stderr
+      case e of
+        E.UserInterrupt -> do
+          STM.atomically $ STM.writeTVar terminating True
+          STM.atomically $ do
+            conns <- STM.readTVar counter
+            case compare conns 0 of
+              GT -> STM.retry
+              EQ -> pure ()
+              LT -> STM.throwSTM NegativeActiveConnections
+          takeMVar done
+        _ -> E.throwIO e
+    )
+
+data NegativeActiveConnections = NegativeActiveConnections
+  deriving stock (Show,Eq)
+  deriving anyclass (Exception)
+
+countBytes :: Stream.Connection -> IO Int
+countBytes !conn = do
+  let go !acc = Stream.receiveOnce conn (16384 - 16) >>= \case
+        Left err -> case err of
+          Stream.ReceiveShutdown -> pure acc
+          -- TODO: log exceptions
+          _ -> do
+            BC8.hPutStr IO.stderr "[WORKER] Client did something unexpected.\n"
+            pure acc
+        Right arr -> do
+          let sz = PM.sizeofByteArray arr
+          IO.hFlush IO.stderr
+          go (acc + sz)
+  n <- go 0
+  IO.hFlush IO.stderr
+  pure n
+
+listenForever :: MVar () -> TVar Int -> TVar Bool -> Stream.Listener -> IO ()
+listenForever !done !counter !terminating !lstn = do
+  BC8.hPutStr IO.stderr "[LISTEN] Waiting for inbound connection.\n"
+  e <- Stream.interruptibleForkAcceptedUnmasked counter terminating lstn
+    (\e _ -> case e of
+      Left Stream.ClosePeerContinuedSending ->
+        BC8.hPutStr IO.stderr "[WORKER] Client continued sending after session had ended.\n"
+      Right () ->
+        BC8.hPutStr IO.stderr "[WORKER] Connection gracefully closed.\n"
+    )
+    (\conn (Stream.Peer _ port) -> do
+      BC8.hPutStr IO.stderr (BC8.concat ["Accepted connection on port ", BC8.pack (show port), "\n"])
+      total <- countBytes conn
+      BC8.hPutStr IO.stderr (BC8.concat ["From peer on port ", BC8.pack (show port), ", received ", BC8.pack (show total), " bytes.\n"])
+    )
+  case e of
+    Right _ -> listenForever done counter terminating lstn
+    Left err -> case err of
+      Stream.AcceptConnectionAborted -> do
+        BC8.hPutStr IO.stderr "[MAIN__] Client reset the connection. Non-fatal.\n"
+        listenForever done counter terminating lstn
+      Stream.AcceptFileDescriptorLimit -> do
+        BC8.hPutStr IO.stderr "[MAIN__] Ran out of file descriptors. Shutting down server.\n"
+        putMVar done ()
+      Stream.AcceptFirewalled -> do
+        BC8.hPutStr IO.stderr "[MAIN__] Local firewall prohibits connection. Shutting down server.\n"
+        putMVar done ()
+      Stream.AcceptInterrupted -> do
+        BC8.hPutStr IO.stderr "[MAIN__] User interrupt. No more connections.\n"
+        putMVar done ()
+  IO.hFlush IO.stderr

--- a/examples/bytemunch/bytemunch.service
+++ b/examples/bytemunch/bytemunch.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Bytemunch application
+After=network.target bytemunch.socket
+Requires=bytemunch.socket
+
+[Service]
+WorkingDirectory=/home/amartin
+ExecStart=/home/amartin/.local/bin/bytemunch
+NonBlocking=True
+ExecStop=/bin/kill -SIGINT $MAINPID
+KillMode=none

--- a/examples/bytemunch/bytemunch.socket
+++ b/examples/bytemunch/bytemunch.socket
@@ -1,0 +1,5 @@
+[Unit]
+Description=Bytemunch Socket
+
+[Socket]
+ListenStream=127.0.0.1:9999

--- a/examples/slowpoke.hs
+++ b/examples/slowpoke.hs
@@ -1,0 +1,53 @@
+{-# language LambdaCase #-}
+{-# language NumericUnderscores #-}
+{-# language OverloadedStrings #-}
+
+{-# OPTIONS_GHC -fforce-recomp -O2 -Wall -Werror #-}
+
+import Control.Concurrent (threadDelay)
+import Control.Exception (Exception,throwIO)
+import Text.Read (readMaybe)
+import System.Environment (getArgs)
+
+import qualified Data.ByteString.Short.Internal as SB
+import qualified Data.Bytes as Bytes
+import qualified Data.Primitive as PM
+import qualified Net.IPv4 as IPv4
+import qualified Socket.Stream.IPv4 as SI
+import qualified Socket.Stream.Uninterruptible.Bytes as SI
+
+main :: IO ()
+main = do
+  getArgs >>= \case
+    [portStr] -> case readMaybe portStr of
+      Nothing -> fail "Argument is not a valid port."
+      Just port -> unhandled $ SI.withConnection
+        (SI.Peer IPv4.loopback port) throwOnCloseException $ \conn -> do
+          let go [] = pure ()
+              go (x : xs) = do
+                unhandled (SI.send conn (Bytes.fromByteArray x))
+                threadDelay 800_000
+                go xs
+          go gettysburgAddress
+    [] -> fail "Expected one argument but got zero."
+    _ -> fail "Expected one argument but more than one."
+
+unhandled :: Exception e => IO (Either e a) -> IO a
+unhandled action = action >>= either throwIO pure
+
+throwOnCloseException :: Either SI.CloseException () -> () -> IO ()
+throwOnCloseException e () = either throwIO pure e
+
+gettysburgAddress :: [PM.ByteArray]
+gettysburgAddress =
+  fmap (\b -> case SB.toShort b of SB.SBS arr -> PM.ByteArray arr)
+    [ "Four score and seven years ago our fathers brought forth on this "
+    , "continent, a new nation, conceived in Liberty, and dedicated to "
+    , "the proposition that all men are created equal. Now we are engaged "
+    , "in a great civil war, testing whether that nation, or any nation so "
+    , "conceived and so dedicated, can long endure. We are met on a great "
+    , "battle-field of that war. We have come to dedicate a portion of that "
+    , "field, as a final resting place for those who here gave their lives "
+    , "that that nation might live. It is altogether fitting and proper that "
+    , "we should do this."
+    ]

--- a/sockets.cabal
+++ b/sockets.cabal
@@ -83,7 +83,7 @@ library sockets-internal
     , base >= 4.11.1.0 && <5
     , bytestring >=0.10 && <0.11
     , ip >= 1.4.1
-    , posix-api >=0.3.2 && <0.4
+    , posix-api >=0.3.3 && <0.4
     , primitive-offset >= 0.2 && <0.3
     , primitive-unlifted >= 0.1 && <0.2
     , primitive-addr >= 0.1 && <0.2
@@ -103,6 +103,7 @@ library sockets-internal
     Socket.Error
     Socket.EventManager
     Socket.IPv4
+    Socket.SequencedPacket
     Socket.Stream
     Socket.Slab
     Socket.Bytes
@@ -155,7 +156,7 @@ library sockets-datagram-send
   build-depends:
     , base >= 4.11.1.0 && <5
     , error-codes >= 0.1.0.1 && < 0.2
-    , posix-api >=0.3.2 && <0.4
+    , posix-api >=0.3.3 && <0.4
     , stm >= 2.4
     , sockets-internal
     , sockets-buffer
@@ -173,7 +174,7 @@ library sockets-datagram-receive
     , base >= 4.11.1.0 && <5
     , error-codes >= 0.1.0.1 && < 0.2
     , stm >= 2.4
-    , posix-api >=0.3.2 && <0.4
+    , posix-api >=0.3.3 && <0.4
     , primitive-offset >= 0.2 && <0.3
     , sockets-internal
     , sockets-buffer
@@ -194,7 +195,7 @@ library sockets-datagram-receive-many
     , base >= 4.11.1.0 && <5
     , error-codes >= 0.1.0.1 && < 0.2
     , stm >= 2.4
-    , posix-api >=0.3.2 && <0.4
+    , posix-api >=0.3.3 && <0.4
     , primitive-unlifted >= 0.1 && <0.2
     , byteslice >= 0.1.1
     , sockets-datagram-receive
@@ -218,13 +219,14 @@ library sockets-stream-send
   build-depends:
     , base >= 4.11.1.0 && <5
     , error-codes >= 0.1.0.1 && < 0.2
-    , posix-api >=0.3.2 && <0.4
+    , posix-api >=0.3.3 && <0.4
     , stm >= 2.4
     , sockets-internal
     , sockets-buffer
     , sockets-interrupt
   exposed-modules:
     Stream.Send.Indefinite
+    SequencedPacket.Send.Indefinite
   signatures:
     Stream.Send
   hs-source-dirs: src-stream-send
@@ -235,13 +237,14 @@ library sockets-stream-receive
   build-depends:
     , base >= 4.11.1.0 && <5
     , error-codes >= 0.1.0.1 && < 0.2
-    , posix-api >=0.3.2 && <0.4
+    , posix-api >=0.3.3 && <0.4
     , stm >= 2.4
     , sockets-internal
     , sockets-buffer
     , sockets-interrupt
   exposed-modules:
     Stream.Receive.Indefinite
+    SequencedPacket.Receive.Indefinite
   signatures:
     Stream.Receive
   hs-source-dirs: src-stream-receive
@@ -252,7 +255,7 @@ library sockets-stream-send-two
   build-depends:
     , base >= 4.11.1.0 && <5
     , error-codes >= 0.1.0.1 && < 0.2
-    , posix-api >=0.3.2 && <0.4
+    , posix-api >=0.3.3 && <0.4
     , stm >= 2.4
     , sockets-internal
     , sockets-interrupt
@@ -288,9 +291,10 @@ library sockets-stream-bidirectional
   reexported-modules:
     , Stream.Send.Indefinite
     , Stream.Receive.Indefinite
+    , SequencedPacket.Receive.Indefinite
   mixins:
       sockets-stream-send (Stream.Send.Indefinite)
-    , sockets-stream-receive (Stream.Receive.Indefinite)
+    , sockets-stream-receive (Stream.Receive.Indefinite,SequencedPacket.Receive.Indefinite)
   default-language: Haskell2010
   ghc-options: -O2 -Wall -j1
 
@@ -301,6 +305,8 @@ library
     Socket.Datagram.IPv4.Connected
     Socket.Datagram.Unix.Unconnected
     Socket.Datagram.Unix.Connected
+    Socket.SequencedPacket.Unix
+    Socket.SequencedPacket.Uninterruptible.Bytes
     Socket.Stream.IPv4
     Socket.Datagram.Interruptible.Addr
     Socket.Datagram.Interruptible.Bytes
@@ -322,6 +328,7 @@ library
     Socket.Stream.Uninterruptible.MutableBytes
     Socket.Stream.Uninterruptible.Hybrid
   other-modules:
+    Socket.Pair
     Socket.Datagram.Common
     Socket.Datagram.Interruptible.MutableBytes.Many
     Socket.Datagram.Uninterruptible.MutableBytes.Many
@@ -461,7 +468,9 @@ library
        Socket.Interrupt as Socket.Interruptible,
        Socket.Buffer as Socket.Bytes),
     sockets-stream-send
-      (Stream.Send.Indefinite as Socket.Stream.Uninterruptible.Bytes.Send)
+      (Stream.Send.Indefinite as Socket.Stream.Uninterruptible.Bytes.Send,
+       SequencedPacket.Send.Indefinite as Socket.SequencedPacket.Uninterruptible.Bytes.Send
+      )
       requires
       (Stream.Send as Socket.Bytes,
        Socket.Interrupt as Socket.Uninterruptible,
@@ -476,7 +485,8 @@ library
        Socket.Interrupt as Socket.Interruptible),
     sockets-stream-bidirectional
       (Stream.Send.Indefinite as Socket.Stream.Uninterruptible.MutableBytes.Send,
-       Stream.Receive.Indefinite as Socket.Stream.Uninterruptible.MutableBytes.Receive)
+       Stream.Receive.Indefinite as Socket.Stream.Uninterruptible.MutableBytes.Receive,
+       SequencedPacket.Receive.Indefinite as Socket.SequencedPacket.Uninterruptible.MutableBytes.Receive)
       requires
       (Stream.Send as Socket.MutableBytes,
        Stream.Receive as Socket.MutableBytes,
@@ -520,7 +530,7 @@ library
     , bytestring >=0.10 && <0.11
     , error-codes >=0.1.0.1 && <0.2
     , ip >=1.4.1
-    , posix-api >=0.3.2 && <0.4
+    , posix-api >=0.3.3 && <0.4
     , primitive-addr >= 0.1 && <0.2
     , primitive-offset >= 0.2 && <0.3
     , primitive-unlifted >= 0.1 && <0.2

--- a/src-internal/Socket.hs
+++ b/src-internal/Socket.hs
@@ -5,9 +5,12 @@
 {-# language DuplicateRecordFields #-}
 {-# language GADTs #-}
 {-# language KindSignatures #-}
+{-# language StandaloneDeriving #-}
 
 module Socket
   ( SocketUnrecoverableException(..)
+  , SocketException(..)
+  , BindException(..)
   , Direction(..)
   , Connectedness(..)
   , Pinnedness(..)
@@ -33,6 +36,7 @@ module Socket
 
 import Control.Exception (Exception(..))
 import Data.Kind (Type)
+import Data.Typeable (Typeable)
 import Foreign.C.Types (CInt)
 
 import qualified Data.List as L
@@ -60,6 +64,54 @@ data Version = V4 | V6
 data Interruptibility = Interruptible | Uninterruptible
 
 data Forkedness = Forked | Unforked
+
+data SocketException :: Type where
+  -- | A limit on the number of open file descriptors has been reached.
+  --   This could be the per-process limit or the system limit.
+  --   (@EMFILE@ and @ENFILE@)
+  SocketFileDescriptorLimit :: SocketException
+
+deriving stock instance Show SocketException
+deriving stock instance Eq SocketException
+deriving anyclass instance Exception SocketException
+
+-- | Recoverable exceptions that happen when establishing stream listeners
+-- or opening datagram sockets.
+--
+-- ==== __Discussion__
+--
+-- The recoverable exceptions that we encounter with stream sockets (established
+-- with @socket@-@bind@-@listen@) and datagram sockets (established with
+-- @socket@-@bind@) are the exact same exceptions. Consequently, we reuse
+-- the same type in both case.
+data BindException :: Family -> Type where
+  -- | The address is protected, and the user is not the superuser. This most
+  --   commonly happens when trying to bind to a port below 1024. On Linux,
+  --   When it is necessary to bind to such a port on Linux, consider using the
+  --   <http://man7.org/linux/man-pages/man7/capabilities.7.html CAP_NET_BIND_SERVICE>
+  --   capability instead of running the process as root. (@EACCES@)
+  BindPermissionDenied :: BindException f
+  -- | The given address is already in use. This can also happen if the
+  --   address was recently bound to and closed. As mandated by
+  --   <https://tools.ietf.org/html/rfc793 RFC 793>, such a socket remains
+  --   in the @TIME-WAIT@ state for a while (commonly 30 to 120 seconds),
+  --   and no new socket may be bound to the address during this period.
+  --   (@EADDRINUSE@ with specified port)
+  BindAddressInUse :: BindException f
+  -- | The port number was specified as zero, but upon attempting to
+  --   bind to an ephemeral port, it was determined that all port numbers
+  --   numbers in the ephemeral port range are currently in use.
+  --   (@EADDRINUSE@ with unspecified port)
+  BindEphemeralPortsExhausted :: BindException ('Internet v)
+  -- | A limit on the number of open file descriptors has been reached.
+  --   This could be the per-process limit or the system limit.
+  --   (@EMFILE@ and @ENFILE@)
+  BindFileDescriptorLimit :: BindException f
+
+deriving stock instance Show (BindException f)
+deriving stock instance Eq (BindException f)
+deriving anyclass instance Typeable f => Exception (BindException f)
+
 
 data SocketUnrecoverableException = SocketUnrecoverableException
   { modules :: String

--- a/src-internal/Socket/EventManager.hs
+++ b/src-internal/Socket/EventManager.hs
@@ -485,7 +485,7 @@ fdToInt = fromIntegral
 --    something less that the full number of bytes requested, we want
 --    to unready the token. The next time we want to @recv@, we want to wait
 --    for the token to be ready before even attempting a @recv@.
--- 2. We want to be properly notification when the peer shuts down. Epoll
+-- 2. We want to be properly notified when the peer shuts down. Epoll
 --    reports this as EPOLLRDHUP.
 --
 -- The difficulty is that, without persistent readiness, performing

--- a/src-internal/Socket/Interruptible.hs
+++ b/src-internal/Socket/Interruptible.hs
@@ -9,6 +9,8 @@ module Socket.Interruptible
   , tokenToStreamReceiveException
   , tokenToDatagramSendException
   , tokenToDatagramReceiveException
+  , tokenToSequencedPacketSendException
+  , tokenToSequencedPacketReceiveException
   ) where
 
 import Socket (Interruptibility(Interruptible))
@@ -18,10 +20,23 @@ import GHC.Exts (RuntimeRep(LiftedRep))
 import qualified Socket.EventManager as EM
 import qualified Socket.Stream as Stream
 import qualified Socket.Datagram as Datagram
+import qualified Socket.SequencedPacket as SequencedPacket
 
 type InterruptRep = 'LiftedRep
 type Interrupt = TVar Bool
 type Intr = 'Interruptible
+
+tokenToSequencedPacketSendException :: Token -> Either (SequencedPacket.SendException 'Interruptible) ()
+{-# inline tokenToSequencedPacketSendException #-}
+tokenToSequencedPacketSendException t = if EM.isInterrupt t
+  then Left SequencedPacket.SendInterrupted
+  else Right ()
+
+tokenToSequencedPacketReceiveException :: Token -> Either (SequencedPacket.ReceiveException 'Interruptible) ()
+{-# inline tokenToSequencedPacketReceiveException #-}
+tokenToSequencedPacketReceiveException t = if EM.isInterrupt t
+  then Left SequencedPacket.ReceiveInterrupted
+  else Right ()
 
 tokenToStreamSendException :: Token -> Int -> Either (Stream.SendException 'Interruptible) ()
 {-# inline tokenToStreamSendException #-}

--- a/src-internal/Socket/SequencedPacket.hs
+++ b/src-internal/Socket/SequencedPacket.hs
@@ -1,0 +1,63 @@
+{-# language DataKinds #-}
+{-# language DeriveAnyClass #-}
+{-# language DerivingStrategies #-}
+{-# language GADTs #-}
+{-# language KindSignatures #-}
+{-# language StandaloneDeriving #-}
+
+module Socket.SequencedPacket
+  ( ReceiveException(..)
+  , SendException(..)
+  ) where
+
+import Data.Kind (Type)
+import Data.Typeable (Typeable)
+import Control.Exception (Exception)
+import Socket (Interruptibility(..))
+
+data ReceiveException :: Interruptibility -> Type where
+  -- | The datagram did not fit in the buffer. The field is the
+  --   original size of the datagram that was truncated. If
+  --   this happens, the process probably needs to start using
+  --   a larger receive buffer.
+  ReceiveTruncated :: ReceiveException i
+  -- | The peer shutdown its writing channel. (zero-length chunk)
+  ReceiveShutdown :: ReceiveException i
+  -- | The peer reset the connection. (@ECONNRESET@)
+  ReceiveReset :: ReceiveException i
+  -- | STM-style interrupt (much safer than C-style interrupt)
+  -- This provides the number of bytes received before the interrupt
+  -- happened. For @receiveOnce@, this will always be zero, but
+  -- for @receiveExactly@ and @receiveBetween@, it may be any
+  -- non-negative number less than the number of bytes the caller
+  -- intended to receive.
+  ReceiveInterrupted :: ReceiveException 'Interruptible
+
+deriving stock instance Eq (ReceiveException i)
+deriving stock instance Show (ReceiveException i)
+deriving anyclass instance Typeable i => Exception (ReceiveException i)
+
+data SendException :: Interruptibility -> Type where
+  -- | The datagram did not fit in the buffer. The field is the
+  --   number of bytes that were successfully copied into the
+  --   send buffer. The datagram does still get sent when this
+  --   happens.
+  SendTruncated :: !Int -> SendException i
+  -- | The local socket has already shutdown its writing channel.
+  --   Consequently, sending is no longer possible. This can happen
+  --   even if the process does not @shutdown@ the socket. If the
+  --   peer decides to @close@ the connection, the local operating system
+  --   will shutdown both the reading and writing channels. (@EPIPE@)
+  SendShutdown :: SendException i
+  -- | The peer reset the connection.
+  SendReset :: SendException i
+  -- | STM-style interrupt (much safer than C-style interrupt).
+  -- This provides the number of bytes sent before the interrupt
+  -- happened. For @sendOnce@, this will always be zero, but
+  -- for @send@, it may be any non-negative number less than the
+  -- number of bytes the caller intended to send.
+  SendInterrupted :: SendException 'Interruptible
+
+deriving stock instance Eq (SendException i)
+deriving stock instance Show (SendException i)
+deriving anyclass instance Typeable i => Exception (SendException i)

--- a/src-internal/Socket/Uninterruptible.hs
+++ b/src-internal/Socket/Uninterruptible.hs
@@ -7,6 +7,8 @@ module Socket.Uninterruptible
   , Interrupt
   , Intr
   , wait
+  , tokenToSequencedPacketSendException
+  , tokenToSequencedPacketReceiveException
   , tokenToStreamSendException
   , tokenToStreamReceiveException
   , tokenToDatagramSendException
@@ -21,12 +23,21 @@ import Socket.EventManager (Token)
 import qualified Socket.EventManager as EM
 import qualified Socket.Stream as Stream
 import qualified Socket.Datagram as Datagram
+import qualified Socket.SequencedPacket as SequencedPacket
 
 -- We use Proxy# instead of () to ensure that this interrupt type
 -- has no runtime cost associated with it.
 type InterruptRep = 'TupleRep '[]
 type Interrupt = Proxy# Void
 type Intr = 'Uninterruptible
+
+tokenToSequencedPacketSendException :: Token -> Either (SequencedPacket.SendException 'Uninterruptible) ()
+{-# inline tokenToSequencedPacketSendException #-}
+tokenToSequencedPacketSendException _ = Right ()
+
+tokenToSequencedPacketReceiveException :: Token -> Either (SequencedPacket.ReceiveException 'Uninterruptible) ()
+{-# inline tokenToSequencedPacketReceiveException #-}
+tokenToSequencedPacketReceiveException _ = Right ()
 
 tokenToStreamSendException ::
      Token

--- a/src-interrupt/Socket/Interrupt.hsig
+++ b/src-interrupt/Socket/Interrupt.hsig
@@ -10,6 +10,7 @@ import Socket.EventManager (Token)
 import Socket (Interruptibility)
 import GHC.Exts (RuntimeRep,TYPE)
 import qualified Socket.Stream as Stream
+import qualified Socket.SequencedPacket as SequencedPacket
 import qualified Socket.Datagram as Datagram
 
 data InterruptRep :: RuntimeRep
@@ -18,6 +19,12 @@ data Intr :: Interruptibility
 
 wait :: Interrupt -> TVar Token -> IO Token
 
+tokenToSequencedPacketSendException ::
+     Token
+  -> Either (SequencedPacket.SendException Intr) ()
+tokenToSequencedPacketReceiveException ::
+     Token
+  -> Either (SequencedPacket.ReceiveException Intr) ()
 tokenToStreamSendException ::
      Token
   -> Int

--- a/src-stream-receive/SequencedPacket/Receive/Indefinite.hs
+++ b/src-stream-receive/SequencedPacket/Receive/Indefinite.hs
@@ -1,0 +1,85 @@
+{-# language BangPatterns #-}
+{-# language LambdaCase #-}
+{-# language MultiWayIf #-}
+
+module SequencedPacket.Receive.Indefinite
+  ( receive
+  , receiveAttempt
+  ) where
+
+import Control.Concurrent.STM (TVar)
+import Foreign.C.Error (Errno(..), eAGAIN, eWOULDBLOCK, eCONNRESET)
+import Foreign.C.Types (CSize)
+import Socket.Error (die)
+import Socket.EventManager (Token)
+import Socket.SequencedPacket (ReceiveException(..))
+import Socket.Buffer (Buffer)
+import Socket.Interrupt (Interrupt,Intr,wait,tokenToSequencedPacketReceiveException)
+import System.Posix.Types (Fd)
+
+import qualified Foreign.C.Error.Describe as D
+import qualified Socket.EventManager as EM
+import qualified Socket.Buffer as Buffer
+import qualified Stream.Receive as Receive
+import qualified Linux.Socket as L
+
+receive ::
+     Interrupt
+  -> Fd
+  -> Buffer
+  -> IO (Either (ReceiveException Intr) Int)
+receive !intr !sock !buf = do
+  let !mngr = EM.manager
+  tv <- EM.reader mngr sock
+  token0 <- wait intr tv
+  case tokenToSequencedPacketReceiveException token0 of
+    Left err -> pure (Left err)
+    Right _ -> receiveLoop intr tv token0 sock buf
+
+receiveAttempt ::
+     Fd -- ^ Socket
+  -> Buffer -- ^ Buffer
+  -> IO (Either (ReceiveException Intr) (Maybe Int))
+{-# inline receiveAttempt #-}
+receiveAttempt !fd !buf = do
+  e <- Receive.receiveOnce fd buf
+  case e of
+    Left err ->
+      if | err == eWOULDBLOCK || err == eAGAIN -> pure (Right Nothing)
+         | err == eCONNRESET -> pure (Left ReceiveReset)
+         | otherwise -> die $ concat
+             [ "Socket.SequencedPacket.receive: " 
+             , describeErrorCode err
+             ]
+    Right recvSz -> do
+      let !recvSzInt = csizeToInt recvSz
+      -- TODO: This is sort of a hack, but it mostly works. We should
+      -- use MSG_TRUNC, but I am too lazy to fix this at the moment.
+      if recvSzInt == Buffer.length buf
+        then pure (Left ReceiveTruncated)
+        else pure (Right (Just recvSzInt))
+
+receiveLoop ::
+     Interrupt
+  -> TVar Token
+  -> Token
+  -> Fd -- ^ Socket
+  -> Buffer -- ^ Buffer
+  -> IO (Either (ReceiveException Intr) Int)
+receiveLoop !intr !tv !token0 !fd !buf = receiveAttempt fd buf >>= \case
+  Left err -> pure (Left err)
+  Right m -> case m of
+    Nothing -> do
+      EM.unready token0 tv
+      token1 <- wait intr tv
+      case tokenToSequencedPacketReceiveException token1 of
+        Left err -> pure (Left err)
+        Right _ -> receiveLoop intr tv token1 fd buf
+    Just !r -> pure (Right r)
+
+csizeToInt :: CSize -> Int
+csizeToInt = fromIntegral
+
+describeErrorCode :: Errno -> String
+describeErrorCode err@(Errno e) = "error code " ++ D.string err ++ " (" ++ show e ++ ")"
+

--- a/src/Socket/Datagram/Unix/Connected.hs
+++ b/src/Socket/Datagram/Unix/Connected.hs
@@ -8,6 +8,7 @@
 {-# language NamedFieldPuns #-}
 {-# language UnboxedTuples #-}
 {-# language ScopedTypeVariables #-}
+{-# language TypeApplications #-}
 
 -- | Unix-domain datagram sockets with a fixed destination.
 module Socket.Datagram.Unix.Connected
@@ -19,10 +20,13 @@ module Socket.Datagram.Unix.Connected
   , Message(..)
     -- * Establish
   , withSocket
+  , withPair
   , connect
   , open
+  , openPair
   , close
     -- * Exceptions
+  , SocketException(..)
   , ConnectException(..)
   , SD.ReceiveException(..)
   , SD.SendException(..)
@@ -31,31 +35,35 @@ module Socket.Datagram.Unix.Connected
   ) where
 
 import Control.Exception (mask,onException)
+import Data.Coerce (coerce)
 import Data.Primitive (ByteArray)
 import Foreign.C.Error (Errno(..),eNOENT,ePROTOTYPE)
 import Foreign.C.Error (eNFILE,eMFILE,eCONNREFUSED)
 import Socket (Connectedness(..),Family(..))
 import Socket.Datagram (Socket(..))
+import Socket (SocketException(..))
 import Socket.Stream (ConnectException(..))
 import Socket.Error (die)
 import Socket.IPv4 (Message(..))
 import Socket.Datagram.Common (close)
 import Socket (Interruptibility(Uninterruptible))
+import System.Posix.Types (Fd)
 
 import qualified Foreign.C.Error.Describe as D
 import qualified Linux.Socket as L
 import qualified Posix.Socket as S
 import qualified Socket as SCK
-import qualified Socket.EventManager as EM
 import qualified Socket.Datagram as SD
+import qualified Socket.EventManager as EM
+import qualified Socket.Pair as Pair
 
 newtype UnixAddress = UnixAddress ByteArray
 
 -- | Unbracketed function for opening a socket. Be careful with
--- this function. These are UNIX-domain datagram sockets on which
--- @connect@ was called without first calling @bind@. This means
--- that they correspond neither to an entry in the filesystem nor
--- an entry in the abstract socket namespace.
+-- this function. The resulting socket is a UNIX-domain datagram socket
+-- on which @connect@ was called without first calling @bind@. This means
+-- that it corresponds neither to an entry in the filesystem nor an entry
+-- in the abstract socket namespace.
 open ::
      UnixAddress
   -> IO (Either (ConnectException 'Unix 'Uninterruptible) (Socket 'Connected 'SCK.Unix))
@@ -77,6 +85,33 @@ open (UnixAddress remote) = do
       S.uninterruptibleConnect fd sockAddr >>= \case
         Left err -> handleConnectException err
         Right (_ :: ()) -> pure (Right (Socket fd))
+
+-- | Unbracketed function for opening a connected socket pair. All warnings
+-- that apply to 'open' apply to this function as well.
+openPair :: IO (Either SocketException (Socket 'Connected 'SCK.Unix, Socket 'Connected 'SCK.Unix))
+openPair = coerce
+  @(IO (Either SocketException (Fd,Fd)))
+  @(IO (Either SocketException (Socket 'Connected 'SCK.Unix, Socket 'Connected 'SCK.Unix)))
+  (Pair.open S.sequencedPacket)
+
+-- | Run a callback that requires a pair of connected
+-- datagram sockets. The sockets will be closed when the
+-- callback completes.
+withPair ::
+     (Socket 'Connected 'SCK.Unix -> Socket 'Connected 'SCK.Unix -> IO a)
+     -- ^ Callback providing the connected datagram sockets
+  -> IO (Either SocketException a)
+withPair f = mask $ \restore -> openPair >>= \case
+  Left err -> pure (Left err)
+  Right (Socket fdA, Socket fdB) -> do
+    a <- onException
+      (restore (f (Socket fdA) (Socket fdB)))
+      (S.uninterruptibleErrorlessClose fdA *> S.uninterruptibleErrorlessClose fdB)
+    S.uninterruptibleClose fdA >>= \case
+      Left err -> die ("Socket.Datagram.Unix.Connected.close: " ++ describeErrorCode err)
+      Right _ -> S.uninterruptibleClose fdB >>= \case
+        Left err -> die ("Socket.Datagram.Unix.Connected.close: " ++ describeErrorCode err)
+        Right _ -> pure (Right a)
 
 withSocket ::
      UnixAddress

--- a/src/Socket/Pair.hs
+++ b/src/Socket/Pair.hs
@@ -1,0 +1,42 @@
+{-# language BangPatterns #-}
+
+module Socket.Pair
+  ( open
+  ) where
+
+import Foreign.C.Error (Errno(..))
+import Foreign.C.Error (eNFILE,eMFILE)
+import Socket (SocketException(..))
+import Socket.Error (die)
+import System.Posix.Types (Fd)
+
+import qualified Foreign.C.Error.Describe as D
+import qualified Linux.Socket as L
+import qualified Posix.Socket as S
+import qualified Socket.EventManager as EM
+
+-- Helper for opening a connected unix-domain socket pair. This is
+-- used by Socket.Datagram.Unix.Connected and by Socket.SequencedPacket.Unix.
+-- It could be used by Socket.Stream.Unix if that module is ever written.
+open :: S.Type -> IO (Either SocketException (Fd, Fd))
+open !typ = do
+  e1 <- S.uninterruptibleSocketPair S.unix
+    (L.applySocketFlags (L.closeOnExec <> L.nonblocking) typ)
+    S.defaultProtocol
+  case e1 of
+    Left err -> handleSocketException err
+    Right (fdA,fdB) -> do
+      let !mngr = EM.manager
+      EM.register mngr fdA
+      EM.register mngr fdB
+      pure (Right (fdA, fdB))
+
+handleSocketException :: Errno -> IO (Either SocketException a)
+handleSocketException e
+  | e == eMFILE = pure (Left SocketFileDescriptorLimit)
+  | e == eNFILE = pure (Left SocketFileDescriptorLimit)
+  | otherwise = die
+      ("Socket.Pair.open: " ++ describeErrorCode e)
+
+describeErrorCode :: Errno -> String
+describeErrorCode err@(Errno e) = "error code " ++ D.string err ++ " (" ++ show e ++ ")"

--- a/src/Socket/SequencedPacket/Uninterruptible/Bytes.hs
+++ b/src/Socket/SequencedPacket/Uninterruptible/Bytes.hs
@@ -1,0 +1,81 @@
+{-# language BangPatterns #-}
+{-# language DataKinds #-}
+{-# language LambdaCase #-}
+{-# language MagicHash #-}
+
+module Socket.SequencedPacket.Uninterruptible.Bytes
+  ( send
+  , trySend
+  , receive
+  , tryReceive
+  ) where
+
+import Socket.SequencedPacket.Unix (Connection(..))
+import Data.Primitive (ByteArray)
+import Data.Bytes.Types (Bytes,MutableBytes(MutableBytes))
+import GHC.Exts (proxy#)
+import Socket (Interruptibility(Uninterruptible))
+import Socket.SequencedPacket (SendException,ReceiveException)
+import Socket.SequencedPacket.Unix (Connection(..))
+
+import qualified Data.Primitive as PM
+import qualified Socket.SequencedPacket.Uninterruptible.Bytes.Send as Send
+import qualified Socket.SequencedPacket.Uninterruptible.MutableBytes.Receive as Receive
+
+-- Sadly, SEQPACKET sockets are poorly documented and, in Linux,
+-- behave inconsisently depending on whether the socket is
+-- internet-domain or unix-domain. More thorough coverage of
+-- this is found at https://stackoverflow.com/q/3595684
+--
+-- Since internet-domain SEQPACKET sockets are rare and unsupported
+-- by most hardware, we only support unix-domain sockets. On Linux,
+-- we can do this by just reusing the send and receive functions for
+-- datagram sockets.
+
+-- | Send a message over a connection.
+send ::
+     Connection -- ^ Connection
+  -> Bytes -- ^ Slice of a buffer
+  -> IO (Either (SendException 'Uninterruptible) ())
+send (Connection !sock) !buf = Send.send proxy# sock buf
+
+-- | Variant of 'send' that never blocks. If the datagram cannot
+-- immidiately be copied to the send queue, returns @False@.
+trySend ::
+     Connection -- ^ Connection
+  -> Bytes -- ^ Slice of a buffer
+  -> IO (Either (SendException 'Uninterruptible) Bool)
+trySend (Connection !sock) !buf = Send.attemptSend sock buf
+
+-- | Receive a message.
+receive ::
+     Connection -- ^ Connection
+  -> Int -- ^ Maximum number of bytes to receive
+  -> IO (Either (ReceiveException 'Uninterruptible) ByteArray)
+{-# inline receive #-}
+receive (Connection conn) !n = do
+  !marr0 <- PM.newByteArray n
+  Receive.receive proxy# conn (MutableBytes marr0 0 n) >>= \case
+    Left err -> pure (Left err)
+    Right sz -> do
+      marr1 <- PM.resizeMutableByteArray marr0 sz
+      !arr <- PM.unsafeFreezeByteArray marr1
+      pure $! Right $! arr
+
+-- | Receive a message. The message may be truncated if the size
+-- of it is larger than the maximum allowed size.
+tryReceive ::
+     Connection -- ^ Connection
+  -> Int -- ^ Maximum message size
+  -> IO (Either (ReceiveException 'Uninterruptible) (Maybe ByteArray))
+tryReceive (Connection !conn) !n = do
+  !marr0 <- PM.newByteArray n
+  Receive.receiveAttempt conn (MutableBytes marr0 0 n) >>= \case
+    Left err -> pure (Left err)
+    Right Nothing -> pure (Right Nothing)
+    Right (Just sz) -> do
+      marr1 <- PM.resizeMutableByteArray marr0 sz
+      !arr <- PM.unsafeFreezeByteArray marr1
+      pure $! Right $! Just $! arr
+
+

--- a/src/Socket/SequencedPacket/Unix.hs
+++ b/src/Socket/SequencedPacket/Unix.hs
@@ -1,0 +1,417 @@
+{-# language BangPatterns #-}
+{-# language DataKinds #-}
+{-# language DeriveAnyClass #-}
+{-# language DerivingStrategies #-}
+{-# language DuplicateRecordFields #-}
+{-# language LambdaCase #-}
+{-# language MagicHash #-}
+{-# language MultiWayIf #-}
+{-# language NamedFieldPuns #-}
+{-# language UnboxedTuples #-}
+{-# language ScopedTypeVariables #-}
+{-# language TypeApplications #-}
+
+-- | Unix-domain @seqpacket@ sockets.
+module Socket.SequencedPacket.Unix
+  ( Connection(..)
+  , Listener(..)
+  , BindException(..)
+  , openPair
+  , withPair
+  , listen
+  , unlisten
+  , unlisten_
+  , withListener
+  , connect
+  , tryConnect
+  , withConnection
+  , withAccepted
+  , accept
+  , disconnect
+  , disconnect_
+  ) where
+
+import Control.Concurrent.STM (TVar)
+import Control.Exception (mask,onException)
+import Data.Coerce (coerce)
+import Data.Primitive (ByteArray)
+import Foreign.C.Error (Errno(..),eNOENT,ePROTOTYPE,eAGAIN,eWOULDBLOCK)
+import Foreign.C.Error (eNFILE,eMFILE,eCONNREFUSED,eNOTCONN)
+import Foreign.C.Error (eADDRINUSE,eACCES,eCONNABORTED,ePERM)
+import Socket (Connectedness(..),Family(..),SocketException(..),BindException(..))
+import Socket.Datagram (Socket(..))
+import Socket.Stream (ConnectException(..),CloseException(..),AcceptException(..))
+import Socket.Error (die)
+import Socket.IPv4 (Message(..))
+import Socket.Datagram.Common (close)
+import Socket (Interruptibility(Uninterruptible))
+import Socket.Datagram.Unix.Connected (UnixAddress(..))
+import System.Posix.Types (Fd)
+
+import qualified Control.Concurrent.STM as STM
+import qualified Data.Primitive as PM
+import qualified Foreign.C.Error.Describe as D
+import qualified Linux.Socket as L
+import qualified Posix.Socket as S
+import qualified Socket as SCK
+import qualified Socket.EventManager as EM
+import qualified Socket.Pair as Pair
+
+newtype Connection = Connection Fd
+
+newtype Listener = Listener Fd
+
+-- | Unbracketed function for opening a connected socket pair. All warnings
+-- that apply to 'open' apply to this function as well.
+openPair :: IO (Either SocketException (Connection, Connection))
+openPair = coerce
+  @(IO (Either SocketException (Fd,Fd)))
+  @(IO (Either SocketException (Connection,Connection)))
+  (Pair.open S.sequencedPacket)
+
+withPair ::
+     (Connection -> Connection -> IO a)
+     -- ^ Callback providing the connected datagram sockets
+  -> IO (Either SocketException a)
+withPair f = mask $ \restore -> openPair >>= \case
+  Left err -> pure (Left err)
+  Right (Connection fdA, Connection fdB) -> do
+    a <- onException
+      (restore (f (Connection fdA) (Connection fdB)))
+      (S.uninterruptibleErrorlessClose fdA *> S.uninterruptibleErrorlessClose fdB)
+    S.uninterruptibleClose fdA >>= \case
+      Left err -> die ("Socket.Datagram.Unix.Connected.close: " ++ describeErrorCode err)
+      Right _ -> S.uninterruptibleClose fdB >>= \case
+        Left err -> die ("Socket.Datagram.Unix.Connected.close: " ++ describeErrorCode err)
+        Right _ -> pure (Right a)
+
+describeErrorCode :: Errno -> String
+describeErrorCode err@(Errno e) = "error code " ++ D.string err ++ " (" ++ show e ++ ")"
+
+-- | Open a socket that is used to listen for inbound connections.
+withListener ::
+     UnixAddress -- ^ Address to bind to (path or abstract namespace name)
+  -> (Listener -> IO a) -- ^ Callback
+  -> IO (Either (BindException 'Unix) a)
+withListener endpoint f = mask $ \restore -> do
+  listen endpoint >>= \case
+    Left err -> pure (Left err)
+    Right sck -> do
+      a <- onException (restore (f sck)) (unlisten_ sck)
+      unlisten sck
+      pure (Right a)
+
+-- | Open a socket that can be used to listen for inbound connections.
+-- Requirements:
+--
+-- * This function may only be called in contexts where exceptions
+--   are masked.
+-- * The caller /must/ be sure to call 'unlistener' on the resulting
+--   'Listener' exactly once to close underlying file descriptor.
+-- * The 'Listener' cannot be used after being given as an argument
+--   to 'unlistener'.
+--
+-- Noncompliant use of this function leads to undefined behavior. Prefer
+-- 'withListener' unless you are writing an integration with a
+-- resource-management library.
+listen :: UnixAddress -> IO (Either (BindException 'Unix) Listener)
+listen (UnixAddress remote) = do
+  e1 <- S.uninterruptibleSocket S.unix
+    (L.applySocketFlags (L.closeOnExec <> L.nonblocking) S.sequencedPacket)
+    S.defaultProtocol
+  case e1 of
+    Left err -> handleSocketListenException err
+    Right fd -> do
+      let sockAddr = id
+            $ S.encodeSocketAddressUnix
+            $ S.SocketAddressUnix
+            $ remote
+      S.uninterruptibleBind fd sockAddr >>= \case
+        Left err -> do
+          S.uninterruptibleErrorlessClose fd
+          handleBindListenException err
+        Right _ -> S.uninterruptibleListen fd 16 >>= \case
+          -- We hardcode the listen backlog to 16. The author is unfamiliar
+          -- with use cases where gains are realized from tuning this parameter.
+          -- Open an issue if this causes problems for anyone.
+          Left err -> do
+            _ <- S.uninterruptibleClose fd
+            handleBindListenException err
+          Right _ -> do
+            -- The getsockname is copied from code in Socket.Datagram.IPv4.Undestined.
+            -- Consider factoring this out.
+            let !mngr = EM.manager
+            EM.register mngr fd
+            pure (Right (Listener fd))
+
+-- | Open a socket and connect to a peer. Requirements:
+--
+-- * This function may only be called in contexts where exceptions
+--   are masked.
+-- * The caller /must/ be sure to call 'disconnect' or 'disconnect_'
+--   on the resulting 'Connection' exactly once to close underlying
+--   file descriptor.
+-- * The 'Connection' cannot be used after being given as an argument
+--   to 'disconnect' or 'disconnect_'.
+--
+-- Noncompliant use of this function leads to undefined behavior. Prefer
+-- 'withConnection' unless you are writing an integration with a
+-- resource-management library.
+connect ::
+     UnixAddress
+     -- ^ Peer address
+  -> IO (Either (ConnectException 'Unix 'Uninterruptible) Connection)
+connect (UnixAddress !remote) = do
+  e1 <- S.uninterruptibleSocket S.unix
+    (L.applySocketFlags (L.closeOnExec <> L.nonblocking) S.sequencedPacket)
+    S.defaultProtocol
+  case e1 of
+    Left err -> handleConnectException err
+    Right fd -> do
+      let sockAddr = id
+            $ S.encodeSocketAddressUnix
+            $ S.SocketAddressUnix
+            $ remote
+      let !mngr = EM.manager
+      -- TODO: I believe it is sound to make both the write and
+      -- read channels start off as not ready. After all, the
+      -- socket is brand new and is not connected to a peer.
+      -- Consequently, there's no way we could miss events.
+      EM.register mngr fd
+      -- This is currently wrong. Redo this later.
+      S.uninterruptibleConnect fd sockAddr >>= \case
+        Left err2 -> do
+          S.uninterruptibleErrorlessClose fd
+          handleConnectException err2
+        Right _ -> pure (Right (Connection fd))
+
+-- | Variant of 'connect' that does not block. Returns 'Nothing' if
+-- the connection cannot be established immidiately.
+tryConnect ::
+     UnixAddress
+     -- ^ Peer address
+  -> IO (Either (ConnectException 'Unix 'Uninterruptible) (Maybe Connection))
+tryConnect (UnixAddress !remote) = do
+  e1 <- S.uninterruptibleSocket S.unix
+    (L.applySocketFlags (L.closeOnExec <> L.nonblocking) S.sequencedPacket)
+    S.defaultProtocol
+  case e1 of
+    Left err -> handleConnectException err
+    Right fd -> do
+      let sockAddr = id
+            $ S.encodeSocketAddressUnix
+            $ S.SocketAddressUnix
+            $ remote
+      let !mngr = EM.manager
+      -- TODO: I believe it is sound to make both the write and
+      -- read channels start off as not ready. After all, the
+      -- socket is brand new and is not connected to a peer.
+      -- Consequently, there's no way we could miss events.
+      EM.register mngr fd
+      -- This is currently wrong. Redo this later.
+      S.uninterruptibleConnect fd sockAddr >>= \case
+        Left err2 -> do
+          S.uninterruptibleErrorlessClose fd
+          if | err2 == eAGAIN -> pure (Right Nothing)
+             | err2 == eWOULDBLOCK -> pure (Right Nothing)
+             | otherwise -> handleConnectException err2
+        Right _ -> pure (Right (Just (Connection fd)))
+
+-- These are the exceptions that can happen as a result
+-- of calling @socket@ with the intent of using the socket
+-- to listen for inbound connections.
+handleSocketListenException :: Errno -> IO (Either (BindException 'Unix) a)
+handleSocketListenException e
+  | e == eMFILE = pure (Left BindFileDescriptorLimit)
+  | e == eNFILE = pure (Left BindFileDescriptorLimit)
+  | otherwise = die ("Socket.SequencedPacket.Unix.socket: " ++ describeErrorCode e)
+
+-- These are the exceptions that can happen as a result
+-- of calling @bind@ with the intent of using the socket
+-- to listen for inbound connections. This is also used
+-- to clean up the error codes of @listen@. The two can
+-- report some of the same error codes, and those happen
+-- to be the error codes we are interested in.
+--
+-- NB: EACCES only happens on @bind@, not on @listen@.
+handleBindListenException :: Errno -> IO (Either (BindException 'Unix) a)
+handleBindListenException !e
+  | e == eACCES = pure (Left BindPermissionDenied)
+  | e == eADDRINUSE = pure (Left BindAddressInUse)
+  | otherwise = die ("Socket.SequencedPacket.Unix.bindListen: " ++ describeErrorCode e)
+
+handleConnectException :: Errno -> IO (Either (ConnectException 'Unix i)  a)
+handleConnectException e
+  | e == eNOENT = pure (Left ConnectNoEntry)
+  | e == ePROTOTYPE = pure (Left ConnectProtocolType)
+  | e == eCONNREFUSED = pure (Left ConnectRefused)
+  | otherwise = die
+      ("Socket.Datagram.Unix.Connected.connect: " ++ describeErrorCode e)
+
+-- | Close a listener. This does not check to see whether or not
+-- the operating system successfully closed the socket. It never
+-- throws exceptions of any kind. This should only be preferred
+-- to 'unlistener' in exception-cleanup contexts where there is
+-- already an exception that will be rethrown. See the implementation
+-- of 'withListener' for an example of appropriate use of both
+-- 'unlistener' and 'unlistener_'.
+unlisten_ :: Listener -> IO ()
+unlisten_ (Listener fd) = S.uninterruptibleErrorlessClose fd
+
+-- | Close a listener. This throws an unrecoverable exception if
+--   the socket cannot be closed.
+unlisten :: Listener -> IO ()
+unlisten (Listener fd) = S.uninterruptibleClose fd >>= \case
+  Left err -> die ("Socket.SequencedPacket.Unix.unlisten: " ++ describeErrorCode err)
+  Right _ -> pure ()
+
+-- | Establish a connection to a server.
+withConnection ::
+     UnixAddress
+     -- ^ Peer address
+  -> (Either CloseException () -> a -> IO b)
+     -- ^ Callback to handle an ungraceful close. 
+  -> (Connection -> IO a)
+     -- ^ Callback to consume connection. Must not return the connection.
+  -> IO (Either (ConnectException 'Unix 'Uninterruptible) b)
+withConnection !remote g f = mask $ \restore -> do
+  connect remote >>= \case
+    Left err -> pure (Left err)
+    Right conn -> do
+      a <- onException (restore (f conn)) (disconnect_ conn)
+      m <- disconnect conn
+      b <- g m a
+      pure (Right b)
+    
+-- | Close a connection gracefully, reporting a 'CloseException' when
+-- the connection has to be terminated by sending a TCP reset. This
+-- uses a combination of @shutdown@, @recv@, @close@ to detect when
+-- resets need to be sent.
+disconnect :: Connection -> IO (Either CloseException ())
+disconnect (Connection fd) = gracefulCloseA fd
+
+gracefulCloseA :: Fd -> IO (Either CloseException ())
+gracefulCloseA fd = do
+  let !mngr = EM.manager
+  !tv <- EM.reader mngr fd
+  token0 <- STM.readTVarIO tv
+  S.uninterruptibleShutdown fd S.write >>= \case
+    -- On Linux (not sure about others), calling shutdown
+    -- on the write channel fails with with ENOTCONN if the
+    -- write channel is already closed. It is common for this to
+    -- happen (e.g. if the peer calls @close@ before the local
+    -- process runs gracefulClose, the local operating system
+    -- will have already closed the write channel). However,
+    -- it does not pose a problem. We just proceed as we would
+    -- have since either way we become certain that the write channel
+    -- is closed.
+    Left err -> if err == eNOTCONN
+      then gracefulCloseB tv token0 fd
+      else do
+        S.uninterruptibleErrorlessClose fd
+        die ("Socket.SequencedPacket.Unix.gracefulCloseA[shutdown]: " ++ describeErrorCode err)
+    Right _ -> gracefulCloseB tv token0 fd
+
+-- The second part of the shutdown function must call itself recursively
+-- since we may receive false read-ready notifications at any time.
+gracefulCloseB :: TVar EM.Token -> EM.Token -> Fd -> IO (Either CloseException ())
+gracefulCloseB !tv !token0 !fd = do
+  !buf <- PM.newByteArray 1
+  S.uninterruptibleReceiveMutableByteArray fd buf 0 1 mempty >>= \case
+    Left err1 -> if err1 == eWOULDBLOCK || err1 == eAGAIN
+      then do
+        token1 <- EM.persistentUnreadyAndWait token0 tv
+        gracefulCloseB tv token1 fd
+      else do
+        _ <- S.uninterruptibleClose fd
+        -- We treat all @recv@ errors except for the nonblocking
+        -- notices as unrecoverable.
+        die ("Socket.SequencedPacket.Unix.gracefulCloseB[recv]: " ++ describeErrorCode err1)
+    Right sz -> if sz == 0
+      then S.uninterruptibleClose fd >>= \case
+        Left err -> 
+          die ("Socket.SequencedPacket.Unix.gracefulCloseB[close]: " ++ describeErrorCode err)
+        Right _ -> pure (Right ())
+      else do
+        _ <- S.uninterruptibleClose fd
+        pure (Left ClosePeerContinuedSending)
+
+-- | Close a connection. This does not check to see whether or not
+-- the connection was brought down gracefully. It just calls @close@.
+-- It never throws exceptions of any kind (even if @close@ fails).
+-- This should only be preferred to 'disconnect' in exception-cleanup
+-- contexts where there is already an exception that will be rethrown.
+-- See the implementation of 'withConnection' for an example of
+-- appropriate use of both 'disconnect' and 'disconnect_'.
+disconnect_ :: Connection -> IO ()
+disconnect_ (Connection fd) = S.uninterruptibleErrorlessClose fd
+
+-- | Accept a connection on the listener and run the supplied callback
+-- on it. This closes the connection when the callback finishes or if
+-- an exception is thrown. Since this function blocks the thread until
+-- the callback finishes, it is only suitable for stream socket clients
+-- that handle one connection at a time. The variant 'forkAcceptedUnmasked'
+-- is preferrable for servers that need to handle connections concurrently
+-- (most use cases).
+withAccepted ::
+     Listener
+  -> (Either CloseException () -> a -> IO b)
+     -- ^ Callback to handle an ungraceful close. 
+  -> (Connection -> IO a)
+     -- ^ Callback to consume connection. Must not return the connection.
+  -> IO (Either (AcceptException 'Uninterruptible) b)
+withAccepted !lstn consumeException cb = do
+  r <- mask $ \restore -> do
+    accept lstn >>= \case
+      Left e -> pure (Left e)
+      Right conn -> do
+        a <- onException (restore (cb conn)) (disconnect_ conn)
+        e <- disconnect conn
+        pure (Right (e,a))
+  -- Notice that consumeException gets run in an unmasked context.
+  case r of
+    Left e -> pure (Left e)
+    Right (e,a) -> fmap Right (consumeException e a)
+
+-- | Listen for an inbound connection.
+accept :: Listener -> IO (Either (AcceptException 'Uninterruptible) Connection)
+accept (Listener !fd) = do
+  -- Although this function must be called in a context where
+  -- exceptions are masked, recall that EM.wait uses an STM
+  -- action that might retry, meaning that this first part is
+  -- still interruptible. This is a good thing in the case of
+  -- this function.
+  let !mngr = EM.manager
+  -- The listener should already be registered, so we can just
+  -- ask for the reader directly.
+  !tv <- EM.reader mngr fd
+  let go !oldToken = do
+        waitlessAccept fd >>= \case
+          Left merr -> case merr of
+            Nothing -> EM.unreadyAndWait oldToken tv >>= go
+            Just err -> pure (Left err)
+          Right r@(Connection conn) -> do
+            EM.register mngr conn
+            pure (Right r)
+  go =<< STM.readTVarIO tv
+
+waitlessAccept :: Fd -> IO (Either (Maybe (AcceptException i)) Connection)
+waitlessAccept !lstn = do
+  -- TODO: add a variant of accept4 in posix-api that discards the peer address.
+  L.uninterruptibleAccept4 lstn 128 (L.closeOnExec <> L.nonblocking) >>= \case
+    Left err -> handleAcceptException err
+    Right (_,_,acpt) -> pure (Right (Connection acpt))
+
+-- These are the exceptions that can happen as a result
+-- of calling @accept@.
+-- TODO: There is no way a UNIX-domain connection could be firewalled.
+-- Is EPERM even possible in this context?
+handleAcceptException :: Errno -> IO (Either (Maybe (AcceptException i)) a)
+handleAcceptException e
+  | e == eAGAIN = pure (Left Nothing)
+  | e == eWOULDBLOCK = pure (Left Nothing)
+  | e == eCONNABORTED = pure (Left (Just AcceptConnectionAborted))
+  | e == eMFILE = pure (Left (Just AcceptFileDescriptorLimit))
+  | e == eNFILE = pure (Left (Just AcceptFileDescriptorLimit))
+  | e == ePERM = pure (Left (Just AcceptFirewalled))
+  | otherwise = die ("Socket.Stream.IPv4.accept: " ++ describeErrorCode e)


### PR DESCRIPTION
Note to self: Do not forget to add a check for `O_NONBLOCKING` for listeners that systemd hands to the process. It is very easy to forget `NonBlocking=True` in a service description, and is it extremely difficult to debug this since it results in the runtime locking up.